### PR TITLE
Change order of gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ eclipse {
 
 repositories {
     mavenLocal()
-    mavenCentral()
     maven { url 'http://download.osgeo.org/webdav/geotools/' }
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Running `gradle build` results in this error:

``` console
FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all dependencies for configuration ':compile'.
> Could not download artifact 'javax.media:jai_core:1.1.3:jai_core.jar'
> Artifact 'javax.media:jai_core:1.1.3:jai_core.jar' not found.
```

Fixed by moving the geotools repo above maven central. From some quick googling, this seemed to be a common problem.
